### PR TITLE
Add myself to author information

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,0 +1,4 @@
+bart_ribbers:
+  name: Bart Ribbers
+  avatar: postmarketos-logo.svg
+  web: https://mastodon.fam-ribbers.com/@bart

--- a/_posts/2020-03-25-Packaging_Glacier_for_postmarketOS.md
+++ b/_posts/2020-03-25-Packaging_Glacier_for_postmarketOS.md
@@ -2,7 +2,7 @@
 layout: article
 title: Packaging Glacier for postmarketOS
 modified: 2020-03-25
-author: Bart Ribbers (PureTryOut)
+author: bart_ribbers
 tags: [main]
 image:
   teaser: postmarketos-logo.svg


### PR DESCRIPTION
With this I should show up properly as the author of https://nemomobile-ux.github.io/pages/Packaging_Glacier_for_postmarketOS/