### PR TITLE
make headers visible when used link to anchor

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -124,7 +124,8 @@ a.btn-social:hover {
     color: _palette(fg-bold);
     font-weight: _font(weight);
     line-height: 1em;
-    margin: 0 0 (_size(element-margin) * 0.25) 0;
+    margin: -100px 0 (_size(element-margin) * 0.25) 0;
+    padding-top: 100px;
 
     a {
       color: inherit;


### PR DESCRIPTION
the behaviour is visible for example on following links: http://localhost:4000/pages/advent-of-code/#7---santas-naughty-or-nice-list http://localhost:4000/pages/advent-of-code/#2--letter-for-santa-claus